### PR TITLE
Upgrading to torso 6.x API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@
         var view = this;
         this.trigger('successServerRetrieval');
 
-        this.collection.fetchByIds(result.list).then(function() {
+        this.collection.trackAndFetch(result.list).then(function() {
           callback(view._prepareData(tableParams, result));
           view._updateFixedHeaderPos();
         });


### PR DESCRIPTION
From what I can tell this this the only non-backwards compatible change that affects this view when upgrading to torso 6.x.
